### PR TITLE
Fix format helpers overflow

### DIFF
--- a/utils/format.ts
+++ b/utils/format.ts
@@ -22,7 +22,7 @@ export const formatFileSize = (fileSize: number) => {
     return fileSize
   const units = ['', 'K', 'M', 'G', 'T', 'P']
   let index = 0
-  while (fileSize >= 1024 && index < units.length) {
+  while (fileSize >= 1024 && index < units.length - 1) {
     fileSize = fileSize / 1024
     index++
   }
@@ -39,7 +39,7 @@ export const formatTime = (seconds: number) => {
     return seconds
   const units = ['sec', 'min', 'h']
   let index = 0
-  while (seconds >= 60 && index < units.length) {
+  while (seconds >= 60 && index < units.length - 1) {
     seconds = seconds / 60
     index++
   }


### PR DESCRIPTION
## Summary
- prevent `formatFileSize` and `formatTime` from indexing past the units array

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68463866918c8324801802b9d2f00b65